### PR TITLE
Add "brew sparkling change_id" command.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'dnssd'
 gem 'faraday'
+gem 'plist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     multipart-post (2.0.0)
+    plist (3.1.0)
 
 PLATFORMS
   ruby
@@ -12,6 +13,7 @@ PLATFORMS
 DEPENDENCIES
   dnssd
   faraday
+  plist
 
 BUNDLED WITH
    1.10.5

--- a/lib/brew_sparkling/action/install/base.rb
+++ b/lib/brew_sparkling/action/install/base.rb
@@ -1,4 +1,5 @@
 require 'brew_sparkling/recipe/recipe'
+require 'brew_sparkling/user'
 
 module BrewSparkling
   module Action
@@ -17,6 +18,10 @@ module BrewSparkling
             xcodebuild -scheme ios-app-sample -archivePath #{archive_path} archive #{xcpretty}
             END
           end
+        end
+
+        def user
+          User.new
         end
 
         def tarball_path

--- a/lib/brew_sparkling/action/install/change_id.rb
+++ b/lib/brew_sparkling/action/install/change_id.rb
@@ -1,0 +1,47 @@
+require 'plist'
+require 'pp'
+
+module BrewSparkling
+  module Action
+    module Install
+      # Free provisioning plan does not provide wildcard provisioning.
+      # So you should use expliict app id.
+      #
+      # But app id require world-wide uniqueness. So we must create
+      # a unique bundle identifier per user.
+      #
+      # Ordinally, bundle identifier is stored at Info.plist. So,
+      # we traversal project directory and rewrite it.
+      class ChangeId < Base
+
+        def call
+          update_info_plist do |plist|
+            update_hash plist, 'CFBundleIdentifier' do |original|
+              "#{original}.#{user.postfix}"
+            end
+          end
+        end
+
+        private
+
+        def update_info_plist(&f)
+          recipe.info_plists.each do |info|
+            original = Plist::parse_xml(info)
+
+            updated = f.call(original)
+
+            File.write info, updated.to_plist
+          end
+        end
+
+        def update_hash(hash, key, &f)
+          if hash.key? key
+            hash[key] = f.call hash[key]
+          end
+
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/brew_sparkling/handler/install.rb
+++ b/lib/brew_sparkling/handler/install.rb
@@ -3,11 +3,12 @@ require 'brew_sparkling/action/install/fetch'
 require 'brew_sparkling/action/install/unpack'
 require 'brew_sparkling/action/install/build'
 require 'brew_sparkling/action/install/install_app'
+require 'brew_sparkling/action/install/change_id'
 
 module BrewSparkling
   module Handler
     class Install < Base
-      command :fetch, :unpack, :build, :install_app
+      command :fetch, :unpack, :build, :install_app, :change_id
 
       def fetch(name=nil)
         Action::Install::Fetch.new.call
@@ -23,6 +24,10 @@ module BrewSparkling
 
       def install_app
         Action::Install::InstallApp.new.call
+      end
+
+      def change_id
+        Action::Install::ChangeId.new.call
       end
     end
   end

--- a/lib/brew_sparkling/recipe/recipe.rb
+++ b/lib/brew_sparkling/recipe/recipe.rb
@@ -22,6 +22,14 @@ module BrewSparkling
         Location.archive_path.join(name, version)
       end
 
+      def info_plists
+        xs = []
+        traversal build_path do |entry|
+          xs << entry if entry.basename.fnmatch? 'Info.plist'
+        end
+        xs
+      end
+
       def app_path
         Location.archive_path.join(name, "#{version}.xcarchive", 'Products', 'Applications', "#{app_name}.app")
       end
@@ -36,6 +44,23 @@ module BrewSparkling
 
       def build
         instance_eval(&@build_code)
+      end
+
+      private
+
+      def traversal(path, &f)
+        directories = [ path ]
+
+        until directories.empty? do
+          d = directories.shift
+          d.each_child do |entry|
+            if entry.directory?
+              directories << entry
+            else
+              f.call entry
+            end
+          end
+        end
       end
     end
   end

--- a/lib/brew_sparkling/user.rb
+++ b/lib/brew_sparkling/user.rb
@@ -1,0 +1,41 @@
+require 'brew_sparkling/gateway/xcode'
+require 'digest/sha1'
+
+module BrewSparkling
+  class User
+    def account
+      @account ||= find_or_first(accounts) { |account|
+        account.username == ENV['BREW_SPARKLING_USERNAME']
+      }
+    end
+
+    def certificate
+      @certificate ||= find_or_first(certificates) { |certificate|
+        certificate.commonName == ENV['BREW_SPARKLING_CERTIFICATE']
+      }
+    end
+
+    def postfix
+      Digest::SHA1.hexdigest account.username
+    end
+
+    private
+
+    def accounts
+      @accounts ||= gateway.accounts
+    end
+
+    def certificates
+      @certificates ||= gateway.certificates
+    end
+
+    def gateway
+      @gateway ||= Gateway::Xcode.default
+    end
+
+    def find_or_first(xs, &f)
+      first = proc { xs.first }
+      xs.find(first, &f)
+    end
+  end
+end


### PR DESCRIPTION
Assign unique id to `BundleIdentifier` to avoid free provisioning constraint. (At free provisioning, you could not use wildcard provisioning)
